### PR TITLE
fix!: disable deprecated overflow highlight

### DIFF
--- a/git-commit-ts-mode.el
+++ b/git-commit-ts-mode.el
@@ -259,11 +259,11 @@ The underlined text will be highlighted using `git-commit-ts-branch-face'."
    :language 'gitcommit
    '((subject) @git-commit-ts-title-face)
 
-   :feature 'overflow
-   :language 'gitcommit
-   :override t
-   '((subject
-      (overflow) @git-commit-ts-overflow-face))
+   ;; :feature 'overflow
+   ;; :language 'gitcommit
+   ;; :override t
+   ;; '((subject
+   ;;    (overflow) @git-commit-ts-overflow-face))
 
    :feature 'prefix
    :language 'gitcommit


### PR DESCRIPTION
Due to changes in the parser (see gbprod/tree-sitter-gitcommit#68), I will have to turn off the overflow highlight. I will try to add overflow support in the near future.