### PR TITLE
fix: Update queries to work with latest tree-sitter-gitcommit

### DIFF
--- a/git-commit-ts-mode.el
+++ b/git-commit-ts-mode.el
@@ -281,7 +281,7 @@ The underlined text will be highlighted using `git-commit-ts-branch-face'."
    :language 'gitcommit
    :override t
    '((subject
-      (subject_prefix) @git-commit-ts-prefix-face))
+      (prefix) @git-commit-ts-prefix-face))
 
    :feature 'prefix
    :language 'gitcommit


### PR DESCRIPTION
I found that at least when using revision
`aa5c279287f0895a7ebc76a06e55ac3e4b2df7c7` of `tree-sitter-gitcommit`, the `subject_prefix` token is now called `prefix`. Renaming the token allows the font lock to work once again for me.

**BREAKING CHANGE:** Instead of querying for `subject_prefix`, we now query for `prefix`. This may have negative consequences for previous versions of `tree-sitter-gitcommit`.

FIXES: #5